### PR TITLE
Division of training loss by no. of batches

### DIFF
--- a/train_test.py
+++ b/train_test.py
@@ -79,7 +79,7 @@ def train(opt, data, device, k):
         #print('learning rate = %.7f' % lr)
 
         if opt.measure or epoch == (opt.niter+opt.niter_decay - 1):
-            loss_epoch /= len(train_loader.dataset)
+            loss_epoch /= len(train_loader)
 
             cindex_epoch = CIndex_lifeline(risk_pred_all, censor_all, survtime_all) if opt.task == 'surv' else None
             pvalue_epoch = cox_log_rank(risk_pred_all, censor_all, survtime_all)  if opt.task == 'surv' else None


### PR DESCRIPTION
Hello,

The original version of the code divides the accumulated training loss by the number of images in the dataset `len(train_loader.dataset)` which - I believe - should not be accurate. The correct implementation should divide by the number of batches `len(train_loader)`, as the returned loss from `CoxLoss` is already averaged across each batch.

Thanks